### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,10 @@ setup(name='geyser',
       author='Zhihan Yue',
       author_email='zhihan.yue@foxmail.com',
       url='https://github.com/yuezhihan/geyser',
-      license='MIT',
       python_requires=">=2.7",
       install_requires=["torch"],
       packages=["geyser"],
+      classifiers=[
+          'License :: OSI Approved :: MIT License'
+      ]
       zip_safe=False)


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.